### PR TITLE
Add GitHub test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,76 @@
+name: Tests
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    name: PHP ${{ matrix.php }} ${{ matrix.additional-extensions }}, ${{ matrix.coverage }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["7.2", "7.3", "7.4"]
+        additional-extensions:
+          - "grpc"
+          - "grpc, protobuf"
+        coverage: ["xdebug", "pcov", "none"]
+
+    env:
+      extensions: ctype, dom, json, mbstring, openssl, xml, zip, zlib, ${{ matrix.additional-extensions }}
+      key: cache-v1-${{ matrix.coverage }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup cache environment
+        id: cache-env
+        uses: shivammathur/cache-extensions@v1
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.extensions }}
+          key: ${{ env.key }}
+
+      - name: Cache extensions
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.cache-env.outputs.dir }}
+          key: ${{ steps.cache-env.outputs.key }}
+          restore-keys: ${{ steps.cache-env.outputs.key }}
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.extensions }}
+          tools: composer, pecl
+          coverage: ${{ matrix.coverage }}
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-${{ env.key }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install dependencies (stable)
+        run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --no-progress
+
+      - name: Save secret
+        shell: bash
+        run: 'echo "$GOOGLE_APPLICATION_CREDENTIALS" > credentials/firebase.json'
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ secrets.GOOGLE_APPLICATION_CREDENTIALS }}
+
+      - name: Setup problem matchers for PHP
+        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+
+      - name: Run Script
+        run: php src/index.php

--- a/README.md
+++ b/README.md
@@ -15,3 +15,16 @@ php src/index.php
 ### Running in a browser
 php -S 127.0.0.1:8000 -t src
 ```
+
+## GitHub Workflow
+
+In order to be able to run the GitHub workflow, the secret `GOOGLE_APPLICATION_CREDENTIALS` needs
+to be filled with a minified Service Account JSON key. You can minify the JSON with
+[jq](https://stedolan.github.io/jq/)
+
+```bash
+cat credentials/firebase.json | jq -c
+
+# On a mac, you can copy it directly with
+cat credentials/firebase.json | jq -c | pbcopy
+```


### PR DESCRIPTION
This adds a test suite to try to replicate the issue in different environments. In order to be able to run it, the secret `GOOGLE_APPLICATION_CREDENTIALS` needs to be set with a minified Service Account JSON key. You can minify the JSON with [jq](https://stedolan.github.io/jq/)

```bash
cat credentials/firebase.json | jq -c

# On a mac, you can copy it directly with
cat credentials/firebase.json | jq -c | pbcopy
```

I've let it run with my credentials at https://github.com/jeromegamez/mgatner-firebase-bug/actions/runs/170393874, and the script is currently failing when the `protobuf` extension is not installed. 

It doesn't seem to matter whether XDebug is installed or not.

:octocat: 

![image](https://user-images.githubusercontent.com/67554/87586240-8ab03880-c6e0-11ea-9eaa-b26a485a027e.png)
